### PR TITLE
Include checksum of plugin binary in release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,9 @@ build:
 		.
 
 package: build
+	@shasum -a 256 ${OUTPUT_DIR}/dist/${NAME}-${VERSION}-${OS_ARCH} | awk '{print $$1}' > ${OUTPUT_DIR}/dist/${NAME}-${VERSION}-${OS_ARCH}.checksum
 	@zip -j -FS -q ${OUTPUT_DIR}/dist/${NAME}-${VERSION}-${OS_ARCH}.zip ${OUTPUT_DIR}/dist/*
-	@shasum -a 256 ${OUTPUT_DIR}/dist/${NAME}-${VERSION}-${OS_ARCH}.zip | awk '{print $$1}' > ${OUTPUT_DIR}/dist/${NAME}-${VERSION}-${OS_ARCH}-sha256.checksum
+	@shasum -a 256 ${OUTPUT_DIR}/dist/${NAME}-${VERSION}-${OS_ARCH}.zip | awk '{print $$1}' > ${OUTPUT_DIR}/dist/${NAME}-${VERSION}-${OS_ARCH}.zip.checksum
 
 tools: goimports
 


### PR DESCRIPTION
Include checksum of plugin binary in release in addition to the existing release dist checksum

This is for convenience when registering the plugin in vault. Before this change, the user had to first verify the download using the released checksum of the zip and then calculate the checksum of the binary themselves for use in the registration process.